### PR TITLE
Switch to react-router v6.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "add123-manifest",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "add123-manifest",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "add123-manifest",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "query-string": "^6.12.1",
@@ -23,9 +23,9 @@
         "standard": "^14.3.4"
       },
       "peerDependencies": {
-        "amiable-forms": "^2.0.0-rc3",
+        "amiable-forms": "^2.0.0-rc2",
         "react": "^16.12.0 || ^17.0.2 || ^18.2.0",
-        "react-router-dom": "^5.1.0"
+        "react-router-dom": "^6.4.1"
       }
     },
     "../use-manifest": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "react": "^16.12.0 || ^17.0.2 || ^18.2.0",
-    "react-router-dom": "^5.1.0",
+    "react-router-dom": "^5.1.0 || ^6.4.1",
     "amiable-forms": "^2.0.0-rc2"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add123-manifest",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A paginated table implementation using React Hooks",
   "main": "./dist/index.js",
   "repository": "https://github.com/autodatadirect/add123-manifest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add123-manifest",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "description": "A paginated table implementation using React Hooks",
   "main": "./dist/index.js",
   "repository": "https://github.com/autodatadirect/add123-manifest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add123-manifest",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "A paginated table implementation using React Hooks",
   "main": "./dist/index.js",
   "repository": "https://github.com/autodatadirect/add123-manifest",
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "react": "^16.12.0 || ^17.0.2 || ^18.2.0",
-    "react-router-dom": "^5.1.0 || ^6.4.1",
+    "react-router-dom": "^6.4.1",
     "amiable-forms": "^2.0.0-rc2"
   },
   "eslintConfig": {

--- a/src/hooks/useUrlParamState.js
+++ b/src/hooks/useUrlParamState.js
@@ -1,4 +1,4 @@
-import { useHistory, useNavigate } from 'react-router'
+import { useNavigate } from 'react-router'
 import queryString from 'query-string'
 import useUrlParams from './useUrlParams'
 
@@ -7,17 +7,10 @@ import useUrlParams from './useUrlParams'
  */
 export default () => {
   const state = useUrlParams()
-
-  let navigateFunction
-  if (useNavigate) {
-    navigateFunction = useNavigate()
-  } else {
-    const history = useHistory()
-    navigateFunction = history.push
-  }
+  const navigate = useNavigate()
 
   return [
     state,
-    newState => navigateFunction({ search: '?' + queryString.stringify({ ...newState }) })
+    newState => navigate({ search: '?' + queryString.stringify({ ...newState }) })
   ]
 }

--- a/src/hooks/useUrlParamState.js
+++ b/src/hooks/useUrlParamState.js
@@ -1,4 +1,4 @@
-import { useHistory } from 'react-router'
+import { useHistory, useNavigate } from 'react-router'
 import queryString from 'query-string'
 import useUrlParams from './useUrlParams'
 
@@ -7,9 +7,17 @@ import useUrlParams from './useUrlParams'
  */
 export default () => {
   const state = useUrlParams()
-  const history = useHistory()
+
+  let navigateFunction
+  if (useNavigate) {
+    navigateFunction = useNavigate()
+  } else {
+    const history = useHistory()
+    navigateFunction = history.push
+  }
+
   return [
     state,
-    newState => history.push({ search: '?' + queryString.stringify({ ...newState }) })
+    newState => navigateFunction({ search: '?' + queryString.stringify({ ...newState }) })
   ]
 }


### PR DESCRIPTION
~~A smidge on the hacky side, but the only other "correct" way that I can find would involve a breaking change, and potentially maintaining another version is IMO not worth it.~~

Edit: Eh. Just use v6. It's fine.